### PR TITLE
Correction in agent_with_memory.ipynb

### DIFF
--- a/docs/extras/modules/memory/agent_with_memory.ipynb
+++ b/docs/extras/modules/memory/agent_with_memory.ipynb
@@ -17,7 +17,7 @@
     "1. We are going to create an LLMChain with memory.\n",
     "2. We are going to use that LLMChain to create a custom Agent.\n",
     "\n",
-    "For the purposes of this exercise, we are going to create a simple custom Agent that has access to a search tool and utilizes the `ConversationBufferMemory` class."
+    "For the purpose of this exercise, we are going to create a simple custom Agent that has access to a search tool and utilizes the `ConversationBufferMemory` class."
    ]
   },
   {


### PR DESCRIPTION
Fixed grammatical error in the sentence by removing "s" from "purposes".