### PR TITLE
Corrected Typo in action.yml file

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - uses: actions/setup-python@v4
-      name: Setup python $${ inputs.python-version }}
+      name: Setup python ${{ inputs.python-version }}
       with:
         python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
Corrected Typo in action.yml file by addressing a minor typographical error. The typo "$" has been corrected to "{" in line 30 .

This improvement enhances the readability and correctness of the notebook, making it easier for users to understand and follow the demonstration. The commit aims to maintain the quality and accuracy of the content within the repository.

@AashishSainiShorthillsAI 