### PR TITLE
Update Mention Instructions for Twitter Credit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -306,4 +306,4 @@ even patch releases may contain [non-backwards-compatible changes](https://semve
 ### 🌟 Recognition
 
 If your contribution has made its way into a release, we will want to give you credit on Twitter (only if you want though)!
-If you have a Twitter account you would like us to mention, please let us know in the PR or in another manner.
+If you have a Twitter account you would like us to mention, please let us know in the pull request (PR) or in another manner.


### PR DESCRIPTION
This pull request updates the mention instructions for Twitter credit. The phrase "PR" has been replaced with "pull request (PR)" for clarity. This change ensures that the text flows smoothly and is easier to understand. No functional changes are made, and this update is solely aimed at improving the language used in the documentation.