### PR TITLE
Fixed error type raised in petals.py

### DIFF
--- a/libs/langchain/langchain/llms/petals.py
+++ b/libs/langchain/langchain/llms/petals.py
@@ -103,7 +103,7 @@ class Petals(LLM):
             values["huggingface_api_key"] = huggingface_api_key
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import transformers or petals python package."
                 "Please install with `pip install -U transformers petals`."
             )


### PR DESCRIPTION
I've refactored the code to ensure that ImportError is consistently handled. Instead of using ValueError as before, I've now followed the standard practice of raising ImportError along with clear and informative error messages. This change enhances the code's clarity and explicitly signifies that any problems are associated with module imports.

